### PR TITLE
add executors for helm, kubectl, and flux

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -12,3 +12,6 @@ commonLabels:
 patchesStrategicMerge:
 - patch-clustername.yaml
 - patch-discord.yaml
+- patch-flux.yaml
+- patch-helm.yaml
+- patch-kubectl.yaml

--- a/patch-flux.yaml
+++ b/patch-flux.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: botkube-civo-demo
+  namespace: flux-system
+spec:
+  chart:
+    spec:
+      chart: botkube
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: botkube
+  interval: 1m0s
+  targetNamespace: botkube
+  values:
+    executors:
+      flux:
+        botkube/flux:
+          config:
+            github:
+              auth:
+                accessToken: ""
+            log:
+              level: info
+          context:
+            rbac:
+              group:
+                prefix: ""
+                static:
+                  #values: ["flux"]  #use this if you want to use flux with elevetaed rbac in the kustomize resources
+                  values:
+                  - botkube-plugins-default
+                type: Static
+          enabled: true

--- a/patch-helm.yaml
+++ b/patch-helm.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: botkube-civo-demo
+  namespace: flux-system
+spec:
+  values:
+    executors:
+      k8s-default-tools:
+        botkube/helm:
+          enabled: true

--- a/patch-kubectl.yaml
+++ b/patch-kubectl.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: botkube-civo-demo
+  namespace: flux-system
+spec:
+  values:
+    executors:
+      k8s-default-tools:
+        botkube/kubectl:
+          enabled: true


### PR DESCRIPTION
This just adds more executors. In the demo live event I forgot to turn on kubectl and helm to be used via botkube. This adds those